### PR TITLE
fix maturin publish

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -148,4 +148,4 @@ jobs:
         if: github.event_name == 'release' && github.event.action == 'created'
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI }}
-        run: maturin publish --username __token__
+        run: maturin publish --username __token__ --interpreter python${{matrix.python_version}}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milagro-bls-binding"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2018"
 authors = ["chihchengliang@gmail.com"]
 


### PR DESCRIPTION
The 1.0.0 release was a fail because we didn't pin the CI jobs to the version they are dedicated to. So job A suppose to publish wheel A but also publish wheel B, which job B already published, so both wheel A and B are failed to publish.