### PR TITLE
upgrade to milagro_bls 1.1.0

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -105,7 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -127,24 +127,6 @@ jobs:
           pip install .
       - name: Build Python package
         run: maturin build --release --no-sdist --strip --interpreter python
-
-      - name: List wheels
-        if: matrix.os == 'windows-latest'
-        run: dir target\wheels\
-
-      - name: List wheels
-        if: matrix.os != 'windows-latest'
-        run: find ./target/wheels/
-
-      # Note: Windows doesn't support glob
-      # https://stackoverflow.com/a/52481267/270334
-      - name: Install wheels
-        if: matrix.os == 'windows-latest'
-        run: pip install --find-links=target\wheels milagro_bls_binding
-
-      - name: Install wheels
-        if: matrix.os != 'windows-latest'
-        run: pip install target/wheels/milagro_bls_binding*.whl
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milagro-bls-binding"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2018"
 authors = ["chihchengliang@gmail.com"]
 
@@ -23,4 +23,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.9.2", features = ["extension-module"] }
-milagro_bls = {git = "https://github.com/sigp/milagro_bls", tag= "v1.0.0" }
+milagro_bls = {git = "https://github.com/sigp/milagro_bls", tag= "v1.1.0" }

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,73 @@
+# FAQ
+
+## Why and when we are allowed to aggregate duplicated messages in AggregateVerify?
+
+@kirk-baird:
+
+> Couple of things worth updating
+>
+> 1. secret keys are now in the range 0 <= sk <= r - 1 according to https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02#section-2.4
+> 2. Messages only need to be distinct if we do not verify ownership of public keys as a protection against the rogue key attack.
+
+@ChihChengLiang:
+
+> thank you for the heads up. how would rouge key attack happen in 2) ?
+> oh, I should rephrase the question. can we avoid rouge key attack without checking the ownership by just making message distinct?
+
+@kirk-baird:
+
+> If you haven't verified the public keys then you can only aggregate one per message:
+> e.g.
+> Let
+
+```
+S1 = H(msg1) * sk1
+S2 = H(msg2) * sk2
+AggSig1 = S1 + S2
+```
+
+> Then we can make
+
+```
+S3 = -S1 = -H(msg1) * sk1 = H(msg1) * (-sk1)
+```
+
+> Note we will also now have `pk3 = -pk1`
+> Thus we can make an aggregate signature
+
+```
+AggSig2 = S1 + S2 + S3
+```
+
+> Now when verifying using the aggregate signature we have input
+
+```
+(AggSig2, (pk1, pk2, pk3), (msg1, msg2, msg1))
+```
+
+> So when we do the pairing
+
+```
+e(pk1, msg1) * e(pk2, msg2) * e(pk3, msg1) = e(pk1, msg1) * e(pk2, msg2) * e(-pk1, msg1)
+```
+
+> Now we have the issue that the pairing `e(a, b) * e(-a, b) = 1`
+> Thus
+
+```
+e(pk1, msg1) * e(pk2, msg2) * e(-pk1, msg1) = e(sk2, msg)
+```
+
+> So by using allowing non-distinct messages we can nullify other users signatures.
+
+> This will only work if you have `e(a, b) * e(-a, b) = 1 OR e(a, b) * e(a, -b) = 1`
+> So to answer you second question if we have different messages (i.e. changing b)
+> Consider `e(pk1, msg1) * e(-pk, msg2) != 1` and thus our pairing still works
+
+@ChihChengLiang:
+
+> thanks that explains clearly!
+
+@kirk-baird:
+
+> No worries happy to help

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This Python package is a performance-focused alternative to [ethereum/py_ecc](ht
 
 This library is unaudited. Please don't use it in production.
 
+For other technical details, see [FAQ](./FAQ.md)
+
 ## Get Started
 
 ```sh

--- a/benchmark.py
+++ b/benchmark.py
@@ -8,7 +8,7 @@ VALIDATORS = 128
 
 @pytest.fixture
 def privkeys():
-    return [(i + 1).to_bytes(48, 'big') for i in range(VALIDATORS)]
+    return [(i + 1).to_bytes(32, 'big') for i in range(VALIDATORS)]
 
 
 @pytest.fixture

--- a/test.py
+++ b/test.py
@@ -15,7 +15,8 @@ from py_ecc.bls.g2_primatives import (
 
 
 def to_bytes(i):
-    return i.to_bytes(48, "big")
+    # Secret key must be 32 bytes
+    return i.to_bytes(32, "big")
 
 
 def bytes_range(l):
@@ -27,8 +28,8 @@ def bytes_range(l):
     [
         (bytes_range(range(1, 10)), range(1, 10), True),
         (bytes_range([1,2,3]), [1,2,3], True),
-        # Test duplicate messages fail
-        (bytes_range([1,2,3]), [42, 69, 42], False),
+        # duplicate messages also work
+        (bytes_range([1,2,3]), [42, 69, 42], True),
     ]
 )
 def test_aggregate_verify(SKs, messages, success):
@@ -49,7 +50,9 @@ def test_aggregate_verify(SKs, messages, success):
         (735),
         (127409812145),
         (90768492698215092512159),
-        # (0),
+        # secret key is allowed to be 0 now
+        # https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-02#section-2.4
+        (0),
     ]
 )
 def test_sign_verify(privkey_int):


### PR DESCRIPTION
Upgrade the binding to milagro_bls [1.1.0](https://github.com/sigp/milagro_bls/releases/tag/v1.1.0)

### Notable changes

- Should include the behavior of [Hash to Curve v07](https://tools.ietf.org/html/draft-irtf-cfrg-hash-to-curve-07)
- A secret key should be 32 bytes
- We are now allowed to aggregate duplicated messages. The distinct messages are required before because the rouge key attack is possible if we don't check the ownership of the public key.