### PR TITLE
release 1.5.1

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -2,7 +2,7 @@ name: Python package
 
 on:
   release:
-    types: [created]
+    types: [published]
   push:
     branches: [master]
   pull_request:
@@ -137,7 +137,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: PyPi publish
-        if: github.event_name == 'release' && github.event.action == 'created'
+        if: github.event_name == 'release' && github.event.action == 'published'
         env:
           MATURIN_PASSWORD: ${{ secrets.PYPI }}
         run: maturin publish --no-sdist --username __token__ --interpreter python

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "milagro-bls-binding"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2018"
 authors = ["chihchengliang@gmail.com"]
 


### PR DESCRIPTION
because the previous release failed to publish to Pypi.

https://github.com/ChihChengLiang/milagro_bls_binding/actions/runs/290840540

Thank @ralexstokes and @protolambda for finding this issue